### PR TITLE
Prevent NullReferenceException

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -56,6 +56,10 @@ namespace BetterActivateSprinklers
 
         private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
         {
+            // Ignore event if world is not loaded and player is not interacting with the world
+            if (!Context.IsPlayerFree)
+                return;
+                
             if (e.Button.IsActionButton())
             {
                 var tile = e.Cursor.GrabTile;


### PR DESCRIPTION
Ignore event if (1) world is not loaded, and (2) player is in the midst of a menu / chest / animation / etc.

This is to suppress the NullReferenceException messages appearing occasionally in SMAPI window.